### PR TITLE
Add CLI support and exportable plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project provides a simple command line interface for viewing Robinhood port
 * Fetches historical portfolio data using `robin_stocks`.
 * Compares portfolio performance to the S&P 500 using `yfinance`.
 * Displays charts for equity history, performance vs S&P 500 and a linear forecast.
+* Command line interface supports non-interactive usage and saving charts to files.
 
 ## Requirements
 
@@ -30,10 +31,17 @@ export RH_MFA="123456"
 Run the dashboard:
 
 ```bash
-python dashboard.py
+python dashboard.py interactive
 ```
 
-A menu will allow you to select different graphs.
+A menu will allow you to select different graphs. You can also run a
+specific graph directly from the command line. For example:
+
+```bash
+python dashboard.py portfolio --span year --interval day -o myplot.png
+```
+
+Use `--help` with any command for additional options.
 
 ## Disclaimer
 


### PR DESCRIPTION
## Summary
- enable saving of charts to files
- add command line interface with subcommands
- document new non-interactive usage
- automatically log out of Robinhood on exit

## Testing
- `python -m py_compile dashboard.py`
- `python dashboard.py --help | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6841b9aa0818832096da9d3843cf4e0c