### PR TITLE
Fix pandas import location

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1,9 +1,7 @@
-import os
 import sys
 import argparse
 import asyncio
 import numpy as np
-import pandas as pd
 import matplotlib.pyplot as plt
 import yfinance as yf
 

--- a/robinhood_api.py
+++ b/robinhood_api.py
@@ -6,8 +6,8 @@ import json
 import time
 from pathlib import Path
 import atexit
-
 import pandas as pd
+
 BASE_URL = "https://api.robinhood.com/"
 TOKEN_FILE = Path.home() / ".rh_token"
 SESSION = None
@@ -96,7 +96,6 @@ async def fetch_portfolio_history(span="year", interval="day", refresh=False):
         data = await resp.json()
     cache_path.write_text(json.dumps(data))
     return data
-import pandas as pd
 
 async def portfolio_history_df(span="year", interval="day", refresh=False):
     data = await fetch_portfolio_history(span, interval, refresh)


### PR DESCRIPTION
## Summary
- move `pandas` import in `robinhood_api.py` to the top import block and remove duplicate
- clean unused imports in `dashboard.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6841df860d2c83208a9106bc423c3173