### PR TITLE
Fix style and wrap lines

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -19,8 +19,17 @@ async def sp500_history(start, end):
     sp.index = sp.index.tz_localize(None)
     return sp
 
-async def async_show_portfolio(span="year", interval="day", output=None, refresh=False):
-    df = await portfolio_history_df(span=span, interval=interval, refresh=refresh)
+async def async_show_portfolio(
+    span="year",
+    interval="day",
+    output=None,
+    refresh=False,
+):
+    df = await portfolio_history_df(
+        span=span,
+        interval=interval,
+        refresh=refresh,
+    )
     fig, ax = plt.subplots()
     df["equity"].plot(ax=ax)
     ax.set_title("Portfolio Value Over Time")
@@ -32,8 +41,17 @@ async def async_show_portfolio(span="year", interval="day", output=None, refresh
     else:
         plt.show()
 
-async def async_show_compare(span="year", interval="day", output=None, refresh=False):
-    df_task = portfolio_history_df(span=span, interval=interval, refresh=refresh)
+async def async_show_compare(
+    span="year",
+    interval="day",
+    output=None,
+    refresh=False,
+):
+    df_task = portfolio_history_df(
+        span=span,
+        interval=interval,
+        refresh=refresh,
+    )
     df = await df_task
     sp_task = sp500_history(df.index[0].date(), df.index[-1].date())
     sp = await sp_task
@@ -51,8 +69,17 @@ async def async_show_compare(span="year", interval="day", output=None, refresh=F
     else:
         plt.show()
 
-async def async_show_forecast(span="year", interval="day", output=None, refresh=False):
-    df = await portfolio_history_df(span=span, interval=interval, refresh=refresh)
+async def async_show_forecast(
+    span="year",
+    interval="day",
+    output=None,
+    refresh=False,
+):
+    df = await portfolio_history_df(
+        span=span,
+        interval=interval,
+        refresh=refresh,
+    )
     y = df["equity"].values
     x = np.arange(len(y))
     coeffs = np.polyfit(x, y, 1)
@@ -130,7 +157,11 @@ def parse_args():
     sub.add_parser("interactive", help="Run interactive menu")
 
     parser.add_argument("--no-login", action="store_true", help="Skip login")
-    parser.add_argument("--refresh", action="store_true", help="Bypass local cache")
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Bypass local cache",
+    )
 
     return parser.parse_args()
 

--- a/robinhood_api.py
+++ b/robinhood_api.py
@@ -44,8 +44,12 @@ async def login():
         TOKEN_INFO = info
         return info["access_token"]
 
-    username = os.getenv("RH_USERNAME") or input("Robinhood username: ")
-    password = os.getenv("RH_PASSWORD") or getpass.getpass("Robinhood password: ")
+    username = os.getenv("RH_USERNAME") or input(
+        "Robinhood username: "
+    )
+    password = os.getenv("RH_PASSWORD") or getpass.getpass(
+        "Robinhood password: "
+    )
     mfa = os.getenv("RH_MFA")
 
     data = {
@@ -68,7 +72,9 @@ async def login():
     info = {"access_token": token, "expires_at": time.time() + expires}
     _save_token(info)
     TOKEN_INFO = info
-    atexit.register(lambda: asyncio.get_event_loop().run_until_complete(logout()))
+    atexit.register(
+        lambda: asyncio.get_event_loop().run_until_complete(logout())
+    )
     return token
 
 async def ensure_token():
@@ -83,16 +89,24 @@ async def fetch_portfolio_history(span="year", interval="day", refresh=False):
     cache_dir = Path(".cache")
     cache_dir.mkdir(exist_ok=True)
     cache_path = cache_dir / f"portfolio_{span}_{interval}.json"
-    if cache_path.exists() and not refresh and (time.time() - cache_path.stat().st_mtime < 24*3600):
+    if cache_path.exists() and not refresh and (
+        time.time() - cache_path.stat().st_mtime < 24 * 3600
+    ):
         return json.loads(cache_path.read_text())
 
     params = {"span": span, "interval": interval}
     headers = {"Authorization": f"Bearer {token}"}
     session = await _get_session()
-    async with session.get(BASE_URL + "portfolios/historicals/", params=params, headers=headers) as resp:
+    async with session.get(
+        BASE_URL + "portfolios/historicals/",
+        params=params,
+        headers=headers,
+    ) as resp:
         if resp.status != 200:
             text = await resp.text()
-            raise RuntimeError(f"Failed to fetch history: {resp.status} {text}")
+            raise RuntimeError(
+                f"Failed to fetch history: {resp.status} {text}"
+            )
         data = await resp.json()
     cache_path.write_text(json.dumps(data))
     return data

--- a/tests/test_robinhood_api.py
+++ b/tests/test_robinhood_api.py
@@ -1,4 +1,7 @@
-import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from unittest.mock import AsyncMock
 import json
 import pytest
@@ -29,7 +32,11 @@ async def test_login_success(tmp_path, monkeypatch):
     mock_session = AsyncMock()
     resp = DummyResponse({"access_token": "tok", "expires_in": 10})
     mock_session.post = lambda *a, **k: DummyCM(resp)
-    monkeypatch.setattr(api, "_get_session", AsyncMock(return_value=mock_session))
+    monkeypatch.setattr(
+        api,
+        "_get_session",
+        AsyncMock(return_value=mock_session),
+    )
     token = await api.login()
     assert token == "tok"
     assert api.TOKEN_INFO["access_token"] == "tok"
@@ -39,8 +46,16 @@ async def test_fetch_portfolio_history(tmp_path, monkeypatch):
     api.TOKEN_FILE = tmp_path / "token.json"
     api.TOKEN_INFO = {"access_token": "tok", "expires_at": 9999999999}
     mock_session = AsyncMock()
-    data = {"historicals": [{"begins_at": "2020-01-01T00:00:00Z", "equity": "1"}]}
+    data = {
+        "historicals": [
+            {"begins_at": "2020-01-01T00:00:00Z", "equity": "1"}
+        ]
+    }
     mock_session.get = lambda *a, **k: DummyCM(DummyResponse(data))
-    monkeypatch.setattr(api, "_get_session", AsyncMock(return_value=mock_session))
+    monkeypatch.setattr(
+        api,
+        "_get_session",
+        AsyncMock(return_value=mock_session),
+    )
     result = await api.fetch_portfolio_history(refresh=True)
     assert result == data


### PR DESCRIPTION
## Summary
- split long function signatures in `dashboard.py`
- wrap long lines in `robinhood_api.py`
- restructure imports and wrap lines in tests
- run ruff and pytest

## Testing
- `ruff check . --line-length 79`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e0ec7ff483209485a005ef3e2374