### PR TITLE
Fix session cleanup with asyncio.run

### DIFF
--- a/robinhood_api.py
+++ b/robinhood_api.py
@@ -36,6 +36,7 @@ async def logout():
     global SESSION
     if SESSION and not SESSION.closed:
         await SESSION.close()
+    SESSION = None
 
 async def login():
     """Authenticate and return access token."""
@@ -73,9 +74,7 @@ async def login():
     info = {"access_token": token, "expires_at": time.time() + expires}
     _save_token(info)
     TOKEN_INFO = info
-    atexit.register(
-        lambda: asyncio.get_event_loop().run_until_complete(logout())
-    )
+    atexit.register(lambda: asyncio.run(logout()))
     return token
 
 async def ensure_token():

--- a/tests/test_robinhood_api.py
+++ b/tests/test_robinhood_api.py
@@ -4,6 +4,7 @@ import pathlib
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from unittest.mock import AsyncMock
 import json
+import asyncio
 import pytest
 import robinhood_api as api
 
@@ -77,3 +78,29 @@ async def test_token_file_permissions(tmp_path, monkeypatch):
     await api.login()
     mode = api.TOKEN_FILE.stat().st_mode & 0o777
     assert mode == 0o600
+
+def test_session_closed_on_exit(tmp_path, monkeypatch):
+    api.TOKEN_FILE = tmp_path / "token.json"
+    monkeypatch.setenv("RH_USERNAME", "u")
+    monkeypatch.setenv("RH_PASSWORD", "p")
+    mock_session = AsyncMock()
+    resp = DummyResponse({"access_token": "tok", "expires_in": 10})
+    mock_session.post = lambda *a, **k: DummyCM(resp)
+    mock_session.close = AsyncMock()
+    mock_session.closed = False
+    async def fake_get_session():
+        api.SESSION = mock_session
+        return mock_session
+    monkeypatch.setattr(api, "_get_session", AsyncMock(side_effect=fake_get_session))
+    registered = []
+
+    def fake_register(func):
+        registered.append(func)
+
+    monkeypatch.setattr(api, "atexit", type("M", (), {"register": fake_register}))
+
+    asyncio.run(api.login())
+    assert registered
+    registered[0]()
+    assert mock_session.close.await_count == 1
+    assert api.SESSION is None


### PR DESCRIPTION
## Summary
- close aiohttp session with `asyncio.run` at exit
- reset `SESSION` after logout
- ensure logout lambda closes the session via new test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841e5eb7f4c8320bd7ccab956711a74