### PR TITLE
Add Gradio CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Install dependencies with:
 pip install -r requirements.txt
 ```
 
+`gradio` is listed as an optional dependency for the notebook interface.
+
 ## Usage
 
 Set your Robinhood credentials in environment variables or enter them when prompted:
@@ -41,6 +43,19 @@ python dashboard.py portfolio --span year --interval day -o myplot.png
 ```
 
 Use `--refresh` to bypass the local cache when you want the latest data.
+
+Launch the Gradio interface from the command line with:
+
+```bash
+python dashboard.py gradio
+```
+
+## Jupyter Notebook
+
+An example notebook `application-launch.ipynb` is provided for exploring the
+dashboard with a Gradio user interface. Simply open the notebook and execute all
+cells. The first cell installs the optional Gradio dependency and the second
+cell launches the interface by calling `dashboard.launch_gradio()`.
 
 ## Disclaimer
 

--- a/application-launch.ipynb
+++ b/application-launch.ipynb
@@ -3,10 +3,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a3d5d945",
+   "id": "576645bf",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "!pip install -q gradio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f75e970",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dashboard\n",
+    "dashboard.launch_gradio()"
+   ]
   }
  ],
  "metadata": {

--- a/dashboard.py
+++ b/dashboard.py
@@ -2,6 +2,8 @@ import sys
 import argparse
 import asyncio
 import numpy as np
+import matplotlib
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import yfinance as yf
 
@@ -96,6 +98,61 @@ async def async_show_forecast(
         plt.show()
 
 
+async def async_portfolio_fig(span="year", interval="day", refresh=False):
+    df = await portfolio_history_df(
+        span=span,
+        interval=interval,
+        refresh=refresh,
+    )
+    fig, ax = plt.subplots()
+    df["equity"].plot(ax=ax)
+    ax.set_title("Portfolio Value Over Time")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Equity ($)")
+    fig.tight_layout()
+    return fig
+
+
+async def async_compare_fig(span="year", interval="day", refresh=False):
+    df_task = portfolio_history_df(
+        span=span,
+        interval=interval,
+        refresh=refresh,
+    )
+    df = await df_task
+    sp_task = sp500_history(df.index[0].date(), df.index[-1].date())
+    sp = await sp_task
+    norm_port = df["equity"] / df["equity"].iloc[0] * 100
+    norm_sp = sp["Adj Close"] / sp["Adj Close"].iloc[0] * 100
+    fig, ax = plt.subplots()
+    ax.plot(norm_port.index, norm_port, label="Portfolio")
+    ax.plot(norm_sp.index, norm_sp, label="S&P500")
+    ax.legend()
+    ax.set_title("Performance vs S&P500")
+    ax.set_ylabel("Performance (Indexed)")
+    fig.tight_layout()
+    return fig
+
+
+async def async_forecast_fig(span="year", interval="day", refresh=False):
+    df = await portfolio_history_df(
+        span=span,
+        interval=interval,
+        refresh=refresh,
+    )
+    y = df["equity"].values
+    x = np.arange(len(y))
+    coeffs = np.polyfit(x, y, 1)
+    trend = coeffs[0] * x + coeffs[1]
+    fig, ax = plt.subplots()
+    ax.plot(df.index, y, label="Actual")
+    ax.plot(df.index, trend, label="Linear Trend", linestyle="--")
+    ax.legend()
+    ax.set_title("Portfolio Forecast")
+    fig.tight_layout()
+    return fig
+
+
 def show_portfolio(span="year", interval="day", output=None, refresh=False):
     asyncio.run(async_show_portfolio(span, interval, output, refresh))
 
@@ -106,6 +163,77 @@ def show_compare(span="year", interval="day", output=None, refresh=False):
 
 def show_forecast(span="year", interval="day", output=None, refresh=False):
     asyncio.run(async_show_forecast(span, interval, output, refresh))
+
+
+def portfolio_fig(span="year", interval="day", refresh=False):
+    """Return a Matplotlib figure of the portfolio history."""
+    return asyncio.run(async_portfolio_fig(span, interval, refresh))
+
+
+def compare_fig(span="year", interval="day", refresh=False):
+    """Return a Matplotlib figure comparing portfolio vs S&P500."""
+    return asyncio.run(async_compare_fig(span, interval, refresh))
+
+
+def forecast_fig(span="year", interval="day", refresh=False):
+    """Return a Matplotlib figure with a simple forecast."""
+    return asyncio.run(async_forecast_fig(span, interval, refresh))
+
+
+def launch_gradio():
+    """Launch a Gradio interface inside a notebook."""
+    import gradio as gr
+
+    def portfolio_handler(span, interval, refresh):
+        return portfolio_fig(span, interval, refresh)
+
+    def compare_handler(span, interval, refresh):
+        return compare_fig(span, interval, refresh)
+
+    def forecast_handler(span, interval, refresh):
+        return forecast_fig(span, interval, refresh)
+
+    portfolio_ui = gr.Interface(
+        portfolio_handler,
+        [
+            gr.Textbox("year", label="Span"),
+            gr.Textbox("day", label="Interval"),
+            gr.Checkbox(False, label="Refresh cache"),
+        ],
+        gr.Plot(),
+        title="Portfolio Value",
+        allow_flagging="never",
+    )
+
+    compare_ui = gr.Interface(
+        compare_handler,
+        [
+            gr.Textbox("year", label="Span"),
+            gr.Textbox("day", label="Interval"),
+            gr.Checkbox(False, label="Refresh cache"),
+        ],
+        gr.Plot(),
+        title="Compare vs S&P500",
+        allow_flagging="never",
+    )
+
+    forecast_ui = gr.Interface(
+        forecast_handler,
+        [
+            gr.Textbox("year", label="Span"),
+            gr.Textbox("day", label="Interval"),
+            gr.Checkbox(False, label="Refresh cache"),
+        ],
+        gr.Plot(),
+        title="Forecast",
+        allow_flagging="never",
+    )
+
+    asyncio.run(login())
+    gr.TabbedInterface(
+        [portfolio_ui, compare_ui, forecast_ui],
+        ["Portfolio", "Compare", "Forecast"],
+    ).launch()
 
 
 def menu(refresh=False):
@@ -155,6 +283,7 @@ def parse_args():
     f.add_argument("-o", "--output", help="Save plot to file")
 
     sub.add_parser("interactive", help="Run interactive menu")
+    sub.add_parser("gradio", help="Launch Gradio interface")
 
     parser.add_argument("--no-login", action="store_true", help="Skip login")
     parser.add_argument(
@@ -168,7 +297,7 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
-    if not args.no_login:
+    if args.command != "gradio" and not args.no_login:
         try:
             asyncio.run(login())
         except Exception as exc:
@@ -181,5 +310,7 @@ if __name__ == "__main__":
         show_compare(args.span, args.interval, args.output, args.refresh)
     elif args.command == "forecast":
         show_forecast(args.span, args.interval, args.output, args.refresh)
+    elif args.command == "gradio":
+        launch_gradio()
     else:
         menu(refresh=args.refresh)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ yfinance
 numpy
 pytest
 pytest-asyncio
+gradio


### PR DESCRIPTION
## Summary
- implement `gradio` subcommand to launch the UI
- document command line usage in README

## Testing
- `pip install -r requirements.txt -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841e99ef2dc8320b70696cdb63d43d5