### PR TITLE
Fix login scope

### DIFF
--- a/robinhood_api.py
+++ b/robinhood_api.py
@@ -58,6 +58,7 @@ async def login():
         "username": username,
         "password": password,
         "grant_type": "password",
+        "scope": "internal",
     }
     if mfa:
         data["mfa_code"] = mfa


### PR DESCRIPTION
## Summary
- add missing `scope` field in login payload

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841ef1b762c8320aad9a0ca1fa4fafb