### PR TITLE
Fix Robinhood login

### DIFF
--- a/robinhood_api.py
+++ b/robinhood_api.py
@@ -59,6 +59,9 @@ async def login():
         "password": password,
         "grant_type": "password",
         "scope": "internal",
+        "client_id": os.getenv(
+            "RH_CLIENT_ID", "c82SH0WZ3apipdQ9AX-7kgKxuLkMTkOW"
+        ),
     }
     if mfa:
         data["mfa_code"] = mfa


### PR DESCRIPTION
## Summary
- add `client_id` when sending the login request to Robinhood

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fdb2f04083208f5feb5bf1b9c00d